### PR TITLE
Add command-line support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ To use, simply drag the \_ren.py file in your game's `game/` folder, then open t
 The tool leaves by default a copy of the untouched file, renamed as .bkp. To disable this, pass `leave_backup=False` to the
 function.
 
+To use it from the command-line, call the tool with the command `sort_translates`, a list of languages, and the option `--backup` to
+generate the backup files. For example, if you want to sort the `french` and `english` translations and not keep any backup,
+call `renpy.sh path/to/your/game sort_translates french english`
+
 ## add_languages
 
 This helps in a situation where you have a game in language A, say french, it's already been translated in B, a more franca
@@ -114,4 +118,12 @@ which you want to add these comments, the open the game, hit Shift+O (the letter
 `translation_tools.add_languages()`. The first parameter should contain either the language or a list of languages you
 want to receive the comments, and the second parameter should receive a list of languages whose transations will be added
 as comments. If the second parameter is not given, all existing translations, except the target ones, will be added as
-comments. You can then delete the \_ren.py and the .rpyc files from your game.
+comments. Additional supported parameters are `remove_old`, which may be set to `True` to remove any existing comment in
+an updated translation's section, and `language_hint`, which may be set to `False` to disable the insertion of the language's
+name before the translated string.
+
+To use it from the command-line, call the tool with the command `add_languages`, a list of languages to update, a list of
+languages to add with the option `-s`, the option `--cleanup` to remove any existing translation example, and the option
+`--no-language` to add translation strings without their source language. For example, if you want to update the `english`
+translation with `french` translations as reference and remove any other reference, call
+`renpy.sh path/to/your/game add_languages french -s english --cleanup --no-language`.

--- a/add_languages_ren.py
+++ b/add_languages_ren.py
@@ -23,6 +23,8 @@ def add_languages(target_langs, lang_list=None):
     But time consumption is not a concern.
     """
 
+    import os
+
     set_all = set(renpy.known_languages())
 
     # checking target_langs
@@ -46,7 +48,7 @@ def add_languages(target_langs, lang_list=None):
             raise ValueError("lang_list contains unknown languages : {}".format(unknowns))
     lang_list -= target_langs
 
-    basedir = renpy.config.basedir.replace("\\", "/") + "/"
+    basedir = renpy.config.basedir
 
     dic = defaultdict(list) # identifier : list of nodes
     for nod in renpy.game.script.all_stmts:
@@ -62,7 +64,7 @@ def add_languages(target_langs, lang_list=None):
                 next = next.next
             start, end = nod.linenumber+1-1, next.linenumber-1
 
-            with renpy.open_file(basedir + nod.filename, "utf-8") as f:
+            with open(os.path.join(basedir, nod.filename), 'r', encoding = "utf-8") as f:
                 filelines = f.read().splitlines()
 
             good_lines = filelines[start:end+1]
@@ -73,10 +75,26 @@ def add_languages(target_langs, lang_list=None):
 
     for nod in sorted(renpy.game.script.all_stmts, key=(lambda n:(n.filename, -n.linenumber))):
         if isinstance(nod, renpy.ast.Translate) and nod.language in target_langs:
-            with renpy.open_file(basedir + nod.filename, "utf-8") as f:
+            long_fn = os.path.join(basedir, nod.filename)
+            with open(long_fn, 'r', encoding = "utf-8") as f:
                 filelines = f.read().splitlines()
 
             filelines.insert(nod.next.linenumber-1, "\n" + "\n\n".join(lines_to_copy[nod.identifier]) + "\n")
             filelines.append("")
-            with open(basedir + nod.filename, "w", encoding="utf-8") as f:
+            with open(long_fn, "w", encoding="utf-8") as f:
                 f.write("\n".join(filelines))
+
+def add_language_command():
+    ap = renpy.arguments.ArgumentParser()
+
+    ap.add_argument("languages", default=[], nargs='*', action="store", help="The translation languages to update.")
+    ap.add_argument("--source-language", "-s", default=[], action="append", help="The commented-out language to add.")
+
+    args = ap.parse_args()
+
+    print("Adding sources to languages {}".format(args.languages))
+    add_languages(args.languages, set(args.source_language) or None)
+
+    exit(0)
+
+renpy.store.renpy.arguments.register_command("add_translation_source", add_language_command)

--- a/add_languages_ren.py
+++ b/add_languages_ren.py
@@ -5,6 +5,7 @@ init python in translation_tools:
 """
 
 from collections import defaultdict
+import os
 
 def add_languages(target_langs, lang_list=None, remove_old = False, language_hint = True):
     """
@@ -22,8 +23,6 @@ def add_languages(target_langs, lang_list=None, remove_old = False, language_hin
     in the first loop, then opening them all, and closing them all in the end.
     But time consumption is not a concern.
     """
-
-    import os
 
     set_all = set(renpy.known_languages())
 
@@ -71,7 +70,9 @@ def add_languages(target_langs, lang_list=None, remove_old = False, language_hin
             good_lines = [line.partition("#")[0].strip() for line in good_lines]
             good_lines = tuple(filter(None, good_lines))
             if good_lines:
-                lines_to_copy[nod.identifier].append("\n".join("    # "+line for line in ((nod.language,) if language_hint else tuple())+good_lines))
+                if language_hint:
+                    good_lines = (nod.language,) + good_lines
+                lines_to_copy[nod.identifier].append("\n".join("    # "+line for line in good_lines))
 
     for nod in sorted(renpy.game.script.all_stmts, key=(lambda n:(n.filename, -n.linenumber))):
         if isinstance(nod, renpy.ast.Translate) and nod.language in target_langs:
@@ -116,4 +117,4 @@ def add_language_command():
 
     exit(0)
 
-renpy.store.renpy.arguments.register_command("add_translation_source", add_language_command)
+renpy.store.renpy.arguments.register_command("add_language", add_language_command)

--- a/add_languages_ren.py
+++ b/add_languages_ren.py
@@ -6,7 +6,7 @@ init python in translation_tools:
 
 from collections import defaultdict
 
-def add_languages(target_langs, lang_list=None, remove_old = False):
+def add_languages(target_langs, lang_list=None, remove_old = False, language_hint = True):
     """
     Adds commented-out translations in the `lang_list` languages
     for each translation of language `target_langs`.
@@ -71,7 +71,7 @@ def add_languages(target_langs, lang_list=None, remove_old = False):
             good_lines = [line.partition("#")[0].strip() for line in good_lines]
             good_lines = tuple(filter(None, good_lines))
             if good_lines:
-                lines_to_copy[nod.identifier].append("\n".join("    # "+line for line in (nod.language,)+good_lines))
+                lines_to_copy[nod.identifier].append("\n".join("    # "+line for line in ((nod.language,) if language_hint else tuple())+good_lines))
 
     for nod in sorted(renpy.game.script.all_stmts, key=(lambda n:(n.filename, -n.linenumber))):
         if isinstance(nod, renpy.ast.Translate) and nod.language in target_langs:
@@ -107,11 +107,12 @@ def add_language_command():
     ap.add_argument("languages", default=[], nargs='*', action="store", help="The translation languages to update.")
     ap.add_argument("--source-language", "-s", default=[], action="append", help="The commented-out language to add.")
     ap.add_argument("--cleanup", "-c", default=False, action="store_true", help="Whether to remove old translation hints.")
+    ap.add_argument("--no-language", dest='language', default=True, action="store_false", help="Disable language name insertion when adding languages.")
 
     args = ap.parse_args()
 
     print("Adding sources to languages {}".format(args.languages))
-    add_languages(args.languages, set(args.source_language) or None, args.cleanup)
+    add_languages(args.languages, set(args.source_language) or None, args.cleanup, args.language)
 
     exit(0)
 

--- a/sort_translates_ren.py
+++ b/sort_translates_ren.py
@@ -1,5 +1,4 @@
 import renpy
-import os
 
 """renpy
 init python in translation_tools:
@@ -7,6 +6,7 @@ init python in translation_tools:
 
 from collections import defaultdict
 import itertools
+import os
 
 def sort_translates(languages=None, leave_backup=True):
     """
@@ -16,7 +16,6 @@ def sort_translates(languages=None, leave_backup=True):
     If `languages` is given, only the translations for these languages are sorted.
     `languages` can be a single language name or a list of language names.
     """
-    import os
 
     set_all = set(renpy.known_languages())
 
@@ -145,4 +144,4 @@ def sort_translates_command():
 
     exit(0)
 
-renpy.store.renpy.arguments.register_command("cleanup_translation", sort_translates_command)
+renpy.store.renpy.arguments.register_command("sort_translates", sort_translates_command)


### PR DESCRIPTION
As said in title, this adds execution from the command-line to the tools, as well as some additional features:
* Run `add_languages` with the command `add_translation_source`
* Run `sort_translates_command` with the command `cleanup_translation`
* Call `open` instead of `renpy.open_file` to circumvent path bug on linux
* Add `remove_old` parameter to `add_languages` to optionally remove existing comments before inserting
* Add `language_hint` parameter to `add_languages` to optionally disable the insertion of the language's name before the quote